### PR TITLE
we dont need subtitles in stories

### DIFF
--- a/story/story.js
+++ b/story/story.js
@@ -61,7 +61,7 @@ async function createNewStory(storyObject) {
 // Checks a given set of params to ensure that the minimum attributes to create 
 // a story are contained inside, returns true or false.
 function isValidStoryData(params) {
-  const storySchema = [ "userId", "uuid", "title", "subtitle", "steps"]
+  const storySchema = [ "userId", "uuid", "title", "steps"]
   return compareKeys(params, storySchema) 
 }
 


### PR DESCRIPTION
removes the subtitle from the schema, as it is not required and is causing errors when the client provides stories without subtitles.